### PR TITLE
fix(rule_base): #20 対称な双椪の片側(待ち5s)が欠落する問題を修正

### DIFF
--- a/src/lib/mahjong/rule_base.ts
+++ b/src/lib/mahjong/rule_base.ts
@@ -255,27 +255,37 @@ export class MahjongRule {
     }
     // 結果保存用の変数
     const concatMianzi:[IMianzi[], MahjongTile[]][] = []
+    // これ以上面子(雀頭)が取れず牌が残った行き止まりの構成を保持する変数
+    // (例: 222 444 を抜いた後に 33 55 が残るような、最大数より少ない面子で
+    //  打ち止まる分解。これを捨てると双椪等の待ちを取りこぼす #20)
+    const stuckMianzi:[IMianzi[], MahjongTile[]][] = []
+    const pushUnique = (dst:[IMianzi[], MahjongTile[]][], candidateHand:[IMianzi[], MahjongTile[]]) => {
+      const currentMianzi = candidateHand[0]
+      if (
+        dst.map(c => c[0])
+          .every(
+            ms => !_.equalSetArray(
+              ms,
+              currentMianzi,
+              (a, b) => this.compareMianzi(a, b))
+          )) {
+        // 同一の面子(雀頭)の組み合わせが無い場合のみ結果に追加する
+        dst.push(candidateHand)
+      }
+    }
     intermediateHand.forEach(i => {
       // 残りの手牌から面子のパターンを抽出
       const takenXZi = takeXZi(i[1])
+      if (takenXZi.length === 0) {
+        // これ以上は取れないが牌が残っている行き止まり構成。
+        // 後続の探索(双椪/塔子待ち等)で利用するため保持しておく。
+        pushUnique(stuckMianzi, i)
+        return
+      }
       takenXZi.forEach(t => {
         // [[...既にある面子, 今とった面子], [残った手牌]]
         const candidateHand:[IMianzi[], MahjongTile[]] = [[...i[0], t[0]], t[1]]
-        // 現在取った面子
-        const currentMianzi = candidateHand[0]
-        // 今迄に取った面子の列
-        const existongConcatMianzi = concatMianzi.map(c => c[0])
-        if (
-          existongConcatMianzi
-            .every(
-              ms => !_.equalSetArray(
-                ms,
-                currentMianzi,
-                (a, b) => this.compareMianzi(a, b))
-            )) {
-          // 同一の面子(雀頭)の組み合わせが無い場合のみ結果に追加する
-          concatMianzi.push(candidateHand)
-        }
+        pushUnique(concatMianzi, candidateHand)
       })
     })
     if (concatMianzi.length === 0) {
@@ -283,7 +293,8 @@ export class MahjongRule {
       // 残った牌と一緒に抜いた面子構成を返却する
       return intermediateHand
     }
-    return this.takeRecursivelyXZi(concatMianzi, takeXZi)
+    // まだ伸ばせる構成は再帰で深掘りし、行き止まり構成はそのまま結果に合流させる
+    return [...this.takeRecursivelyXZi(concatMianzi, takeXZi), ...stuckMianzi]
   }
 
   /**

--- a/tests/unit/galaxy_rule/solve_hule_tile.spec.ts
+++ b/tests/unit/galaxy_rule/solve_hule_tile.spec.ts
@@ -20,6 +20,23 @@ describe('通常形上がり牌探索', () => {
     expect(wait.length).toBe(6)
   })
 
+  it('対称な双椪の片側を取りこぼさない', () => {
+    // #20 真症状: 222 33 444 55 は 3 面子+雀頭の一歩手前。
+    // 3s で和了 = 222/333/444 + 雀頭55、対称な 5s で和了 = 222/444/555 + 雀頭33。
+    // 仕様(3面子+1雀頭)から人手で導いた正しい待ち = {3s, 4s, 5s, 6s}。
+    // 以前は対称解の片側(5s)を列挙で取りこぼしていた。
+    const hand = parser('2s2s2s3s3s4s4s4s5s5s')
+    const wait = GALAXY_RULE.solveHuleTile(hand)
+    const waitTiles = _.uniq(
+      wait.map(([mianzi, tiles, form]) => tiles).flat(),
+      (ta, tb) => GALAXY_RULE.compareTileByNumber(ta, tb)
+    )
+    expect(waitTiles.length).toBe(4)
+    parser('3s4s5s6s').forEach(w => {
+      expect(waitTiles).toContainEqual(w)
+    })
+  })
+
   it('双椪判定', () => {
     const hand = parser('nnlglg')
     const wait = GALAXY_RULE.solveHuleTile(hand)


### PR DESCRIPTION
## 概要
Issue #20「待ち判定が誤る」の本来の症状を修正します。issue 添付のスクリーンショット（手牌 `2s2s2s 3s3s 4s4s4s 5s5s`）で、待ち牌が `{3s, 4s, 6s}` となり **5s が欠落**していました（正しくは `{3s, 4s, 5s, 6s}`）。

## 真因
`src/lib/mahjong/rule_base.ts` の `takeRecursivelyXZi` が「最大数の面子が取れた分解」しか返さず、`222/444` を抜いて `33 55` が残る（最大より1面子少ない）**行き止まり分解を再帰の途中で捨てて**いました。この分解は双椪待ち（`33`→3s, `55`→5s）の素材で、捨てられたため 5s 和了が列挙されませんでした（3s・6s は別経路で出るため残存）。

5s 完成形 `222 / 444 / 555 + 33(雀頭)` と、対称な 3s 完成形 `222 / 333 / 444 + 55(雀頭)` のうち、後者だけが出ていた非対称が症状です。

## 修正
行き止まり構成（`takeXZi` がこれ以上取れず牌が残る）を `stuckMianzi` に保持し、再帰結果へ合流させます。完全形（3面子+1雀頭）を要求する既存呼び出し（`solveNormalHand` / `takeQiDuizi` 等）は `remaindHand.length === 0` で絞るため**影響なし**。重複排除は `pushUnique` に共通化。

## テスト
`tests/unit/galaxy_rule/solve_hule_tile.spec.ts` に「対称な双椪の片側を取りこぼさない」を追加。待ち = `{3s,4s,5s,6s}`（**期待値は「3面子+1雀頭」の定義から人手で導出**。実装出力の写経ではない）。`npm run test:unit` 全 **74 green**（#28 のクラッシュ修正と共存）。

## 関連
Refs #20。PR #28（雀頭なし手のクラッシュ）とは**同じ関数の別バグ・別修正**で、本PRは #28 マージ後の main の上に積んでいます。
