### PR TITLE
docs: デプロイトリガーの記述修正(#19) と 風牌コメントの英訳修正(#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 
 GitHub Actions によって CI/CD が組まれています。
 
-* main 以外への branch への push
+* main 以外への branch への push、および main 向けの pull request
   * UT が自動的に走ります。カバレッジも表示されますが、表示されるだけです。
 
-* main への merge
+* `v` から始まるタグ (`v**`) の push
   * <https://minori-akizuki.github.io/Galaxy_Mahjong/> にページがデプロイされます
 
 ## Project setup

--- a/src/lib/mahjong/tile_map.ts
+++ b/src/lib/mahjong/tile_map.ts
@@ -26,13 +26,13 @@ export const tileMap:TileMap = {
     s: { color: TileColor.siozi, maxNumber: 9 }
   },
   symboledTileMap: {
-    /** 東(west) */
+    /** 東(east) */
     w: { color: TileColor.feng, number: 1 },
     /** 南(south) */
     s: { color: TileColor.feng, number: 2 },
-    /** 西(east) */
+    /** 西(west) */
     e: { color: TileColor.feng, number: 3 },
-    /** 北(noath) */
+    /** 北(north) */
     n: { color: TileColor.feng, number: 4 },
     /** 白(bai ban) */
     b: { color: TileColor.sanyuan, number: 1 },


### PR DESCRIPTION
ドキュメント/コメントの軽微修正2件をまとめています。

## #19: デプロイタイミングの記述が実態と不一致
実際のデプロイトリガーは `.github/workflows/build_deploy.yml` の `on: push: tags: - "v**"`（**`v` 始まりタグの push**）。README の「main への merge でデプロイ」は誤りだったため、タグ push でデプロイされる旨に修正。
あわせて UT は `unit_test.yml` の通り「main 以外への push」に加え「main 向け pull request」でも走るため、その旨を追記。

## #26: 風牌コメントの英訳誤り
`src/lib/mahjong/tile_map.ts` のコメントで 東/西 の英訳が逆、北が typo（`noath`）。**東=east / 西=west / 北=north** に修正。number 値・ロジックは不変。

## テスト
コメント・README のみの変更。`npm run test:unit` 全 74 green（回帰なし）。

Closes #19
Closes #26
