### PR TITLE
test: #20関連の回帰テスト拡充 (#29 待ち探索レベル / #30 銀河の雀頭なし手)

### DIFF
--- a/tests/unit/galaxy_rule/issue29_solve_hule_tile_pairless_path.spec.ts
+++ b/tests/unit/galaxy_rule/issue29_solve_hule_tile_pairless_path.spec.ts
@@ -1,0 +1,59 @@
+import { GalaxyMahjongRule } from '@/lib/mahjong/galaxy_rule'
+import { _ } from '@/lib/util/util'
+
+const RULE = GalaxyMahjongRule.getInstance()
+const parser = (s:string) => RULE.parser.parseTiles(s)
+
+/** solveHuleTile の待ち牌集合を、色・数の重複を除いた文字列ソート配列で取り出すヘルパ。 */
+const waitTileSet = (hand:ReturnType<typeof parser>):string[] => {
+  const wait = RULE.solveHuleTile(hand)
+  const tiles = _.uniq(
+    wait.map(([_mianzis, tiles, _form]) => tiles).flat(),
+    (ta, tb) => RULE.compareTileByNumber(ta, tb)
+  )
+  return tiles.map(t => t.toString()).sort()
+}
+
+// 【#29 待ち牌探索(solveHuleTile)レベルの回帰テスト】
+//
+// 背景（監査指摘）:
+//   #28 の修正テスト(issue20_pairless_crash.spec.ts)は solveHand 単体での
+//   クラッシュ非再現のみを検証しており、ユーザー症状の経路である
+//   solveHuleTile レベルの回帰テストが無い。
+//   solveHuleTile は手牌から面子/雀頭を再帰的に抜く takeRecursivelyXZi を
+//   直接駆動するため、(a) 補完過程で面子が取りきれず牌が残る/雀頭が無い
+//   中間構成が現れても探索が壊れないこと、(b) 対称な双椪解の片側を
+//   取りこぼさず正しい待ちを返すこと、を public 経路で担保する。
+//
+// 期待値の根拠（いずれも spec 由来であり実装出力ではない）:
+//   - 「両面」待ちの待ち牌は連続2枚の両端2種 (spec §5.1)。
+//   - 標準形は「3面子+1雀頭の一歩手前」から待ちを導く (spec §4.1, §5)。
+//     222s/444s + 789w の3面子に対し、雀頭候補が 33s と 55s の双方ありえ、
+//     さらに 345s 順子化を含めると待ちは {3s,4s,5s,6s} の4種 (spec §3,§5)。
+describe('[bug #29] solveHuleTile は補完過程で壊れず双椪の片側も取りこぼさない', () => {
+  it('(a) 面子優先探索で行き止まり構成が生じても例外を投げず両面の待ちを返す', () => {
+    // 1w1w 234w 567w 234s + 6s7s（両面塔子）の13枚聴牌。
+    // solveHuleTile は面子を最大限抜く過程で雀頭の取れない/牌の余る
+    // 中間構成を生成しうるが、探索全体が壊れてはならない。
+    // spec §5.1「両面」より、6s7s の待ちは両端 5s と 8s。
+    const hand = parser('1w1w2w3w4w5w6w7w2s3s4s6s7s')
+
+    expect(() => RULE.solveHuleTile(hand)).not.toThrow()
+    expect(waitTileSet(hand)).toEqual(['5s', '8s'])
+  })
+
+  it('(b) 完全な13枚聴牌の対称な双椪でも片側(5s)を取りこぼさない', () => {
+    // 789w（完成面子）+ 索子 222s 33s 444s 55s の13枚聴牌。
+    // 索子部は #20 スクショ手(2s2s2s3s3s4s4s4s5s5s)と同じ「3面子+雀頭の
+    // 一歩手前」構造だが、ここでは 789w を加えた完全な13枚聴牌として
+    // solveHuleTile を public 経路で検証する（既存テストは10枚の索子断片のみ）。
+    // 3s 和了 = 222s/333s/444s+雀頭55s、対称な 5s 和了 = 222s/444s/555s+雀頭33s、
+    // さらに 345s 順子待ちを含め、仕様(3面子+1雀頭)から導いた正しい待ち = {3s,4s,5s,6s}。
+    // 以前は対称解の片側(5s)を再帰の途中で捨てて取りこぼしていた。
+    const hand = parser('7w8w9w2s2s2s3s3s4s4s4s5s5s')
+
+    expect(() => RULE.solveHuleTile(hand)).not.toThrow()
+    const waitTiles = waitTileSet(hand)
+    expect(waitTiles).toEqual(['3s', '4s', '5s', '6s'])
+  })
+})

--- a/tests/unit/galaxy_rule/issue30_galaxy_pairless_crash.spec.ts
+++ b/tests/unit/galaxy_rule/issue30_galaxy_pairless_crash.spec.ts
@@ -1,0 +1,45 @@
+import { GalaxyMahjongRule } from '@/lib/mahjong/galaxy_rule'
+
+const RULE = GalaxyMahjongRule.getInstance()
+const parser = (s:string) => RULE.parser.parseTiles(s)
+
+// 【#30 銀河牌を含む「雀頭なし手」のクラッシュ非再現テスト】
+//
+// 背景（監査指摘）:
+//   #28 の修正テスト(issue20_pairless_crash.spec.ts)は非銀河の手のみを扱う。
+//   銀河牌(ワイルドカード)を含む手では makeMianzi が色・数を複数候補に
+//   展開するため、面子/雀頭分解の分岐条件が非銀河手と異なりうる。
+//   銀河牌を含みつつ雀頭が一つも取れない手でも、#28 のガードが効いて
+//   takeRecursivelyXZi が empty-intermediate で壊れないことを確認する。
+//
+// 期待値の根拠 (spec §1.3 / §3.1 / §4):
+//   - 銀河の数牌は「同じ数字ならどの色にもなれる」が「数字までは自由にならない」。
+//     よって銀河牌は『同じ数字の牌が他に1枚も無ければ対子を作れない』。
+//   - 銀河の風牌は「どの風牌にもなれる」が、風牌が他に1枚も無ければ対子を作れない。
+//   - 「雀頭が1枚も作れない手」は和了形(標準形/七対子/国士)たりえず空配列を返すべきで、
+//     例外を投げてはならない。
+//   いずれも実装出力ではなく仕様から導いた期待値である。
+describe('[bug #30] solveHand は銀河牌を含む雀頭なし手でも壊れず空を返す', () => {
+  it('銀河の数牌(5sg)を含むが同数の牌が他に無く雀頭が作れない14枚手でも投げない', () => {
+    // 1w2w3w4w 6w7w8w9w 1p2p3p4p 6p + 5sg。
+    // 数 5 の牌は銀河牌 5sg ただ1枚 → 5sg は対子相手を持たない。
+    // 他の牌も全て (色,数) が相異なり対子化不能 → 雀頭ゼロ。
+    const hand = parser('1w2w3w4w6w7w8w9w1p2p3p4p6p5sg')
+
+    expect(hand.some(t => t.option.isGalaxy)).toBe(true)
+    expect(() => RULE.solveHand(hand)).not.toThrow()
+    expect(RULE.solveHand(hand).length).toBe(0)
+  })
+
+  it('銀河の風牌(北g)を含むが他に風牌が無く雀頭が作れない14枚手でも投げない', () => {
+    // 1w2w3w 6w7w8w9w 1p2p3p 6p7p8p + ng(北の銀河牌)。
+    // 風牌は ng ただ1枚 → どの風にもなれるが対子相手の風牌が無い。
+    // ng の内部数(北=4)と衝突しないよう数 4 の牌は手牌に入れていないため
+    // 数牌側とも対子を作れない → 雀頭ゼロ。
+    const hand = parser('1w2w3w6w7w8w9w1p2p3p6p7p8png')
+
+    expect(hand.some(t => t.option.isGalaxy)).toBe(true)
+    expect(() => RULE.solveHand(hand)).not.toThrow()
+    expect(RULE.solveHand(hand).length).toBe(0)
+  })
+})


### PR DESCRIPTION
#20 の2修正（#28 クラッシュ／#31 待ち5s欠落）に対する**回帰テストの拡充**です。本番コードの変更はなく、テスト追加のみ。

## #29: 待ち牌探索(`solveHuleTile`)レベルの回帰
- (a) 行き止まり構成が生じても両面待ちが正しく列挙される（特定fix非依存の一般ガード）。
- (b) 13枚の完全聴牌の対称双椪で片側 `5s` を取りこぼさない（#31 の `stuckMianzi` を守る。既存の10枚断片テストとは別手で非重複）。
- 注: 当初 issue は「`solveHuleTile` が補完過程で `solveHand` を呼び雀頭なし手でクラッシュ」を想定していたが、**現コードでは `solveHuleTile` は `solveHand` を呼ばず**、#28 のクラッシュは `solveHuleTile` 経由では到達不能。よって #28 の回帰ガードは `solveHand` 経由（=#30）で担保する形に再設計。

## #30: 銀河牌を含む「雀頭なし手」のクラッシュ非再現
- 銀河数牌(`5sg`)・銀河風牌(`北g`)を含む雀頭なし14枚手で `solveHand` が throw せず `[]` を返す（#28 ガードを銀河牌でも担保）。

## テスト
`npm run test:unit` 全 **78 green**（+4）。期待値は仕様（4面子1雀頭・待ち形定義）から導出し、各テストは**対応する修正を revert すると fail**することを確認済み（回帰ガードとして有効）。

Closes #29
Closes #30
