### PR TITLE
fix(galaxy_rule): #34 銀河の字牌が同番号の数牌と同一視される問題を修正

### DIFF
--- a/src/lib/mahjong/galaxy_rule.ts
+++ b/src/lib/mahjong/galaxy_rule.ts
@@ -64,8 +64,15 @@ export class GalaxyMahjongRule extends MahjongRule {
           // 三元牌だった場合は三元牌かどうかだけ調べる
           return targetTile.color === TileColor.sanyuan
         default: {
-          // 数牌の場合は数字だけ比べる
-          return tile.number === expect.number
+          // 非銀河側が数牌の場合。
+          // 銀河側(targetTile)も数牌(風でも三元でもない)である事を併せて確認する。
+          // 風牌・三元牌は内部 number を持つ(北=4 等)ため、数字だけ比べると
+          // 字牌と同番号の数牌が誤って同一視されてしまう(#34)。
+          return (
+            targetTile.color !== TileColor.feng &&
+            targetTile.color !== TileColor.sanyuan &&
+            tile.number === expect.number
+          )
         }
       }
     }

--- a/tests/unit/galaxy_rule/issue34_galaxy_honor_vs_number.spec.ts
+++ b/tests/unit/galaxy_rule/issue34_galaxy_honor_vs_number.spec.ts
@@ -1,0 +1,76 @@
+import { GalaxyMahjongRule } from '@/lib/mahjong/galaxy_rule'
+import { MahjongTile } from '@/lib/mahjong/mahjong_tile'
+
+const GALAXY_RULE = GalaxyMahjongRule.getInstance()
+const parseTiles = (str:string):MahjongTile[] => GALAXY_RULE.parser.parseTiles(str)
+
+/**
+ * Issue #34: 銀河の字牌が同番号の数牌と同一視されてはならない。
+ *
+ * 仕様根拠（spec.md §1.3）:
+ *   銀河牌は「数牌＝数字固定・色は数牌の範囲で自由／字牌＝同カテゴリ内
+ *  （風は風・三元は三元）で自由」。**字牌と数牌をまたいで同一視してはならない**。
+ *
+ * 内部 number（tile_map.ts）: 風 東=1,南=2,西=3,北=4 / 三元 白=1,發=2,中=3。
+ * 数牌は number=1..9。よって 北g(feng,4) と 4s(siozi,4) は number が一致するため、
+ * カテゴリ未検査の実装では誤って同一視される。
+ */
+describe('Issue #34: 銀河字牌と数牌のカテゴリまたぎ同一視の禁止', () => {
+  describe('直るべき false（字牌と数牌をまたいではならない）', () => {
+    it('銀河の北(feng,4)は数牌の4索とは同一視できない', () => {
+      const [ng, s4] = parseTiles('ng4s') // ng = 銀河の北(feng,4), s4 = 4索(siozi,4)
+      expect(ng.option.isGalaxy).toBeTruthy()
+      expect(GALAXY_RULE.canBeSameTile(ng, s4)).toBeFalsy()
+    })
+
+    it('引数の順序を入れ替えても同様（4索 と 銀河の北）', () => {
+      const [s4, ng] = parseTiles('4sng') // s4 = 4索(siozi,4), ng = 銀河の北(feng,4)
+      expect(ng.option.isGalaxy).toBeTruthy()
+      expect(GALAXY_RULE.canBeSameTile(s4, ng)).toBeFalsy()
+    })
+
+    it('銀河の西(feng,3)は数牌の3索/3萬/3筒とは同一視できない', () => {
+      const [eg] = parseTiles('eg') // e = 西(feng,3)
+      const [s3, w3, p3] = parseTiles('3s3w3p')
+      expect(eg.option.isGalaxy).toBeTruthy()
+      expect(GALAXY_RULE.canBeSameTile(eg, s3)).toBeFalsy()
+      expect(GALAXY_RULE.canBeSameTile(eg, w3)).toBeFalsy()
+      expect(GALAXY_RULE.canBeSameTile(eg, p3)).toBeFalsy()
+    })
+
+    it('銀河の三元(發=sanyuan,2)は数牌の2索/2萬/2筒とは同一視できない', () => {
+      const [lg] = parseTiles('lg') // l = 發(sanyuan,2)
+      const [s2, w2, p2] = parseTiles('2s2w2p')
+      expect(lg.option.isGalaxy).toBeTruthy()
+      expect(GALAXY_RULE.canBeSameTile(lg, s2)).toBeFalsy()
+      expect(GALAXY_RULE.canBeSameTile(lg, w2)).toBeFalsy()
+      expect(GALAXY_RULE.canBeSameTile(lg, p2)).toBeFalsy()
+    })
+
+    it('逆向き（数牌の銀河と字牌）も同一視できない: 銀河4索 と 北', () => {
+      const [s4g] = parseTiles('4sg')
+      const [n] = parseTiles('n') // 北(feng,4)
+      expect(s4g.option.isGalaxy).toBeTruthy()
+      expect(GALAXY_RULE.canBeSameTile(s4g, n)).toBeFalsy()
+    })
+  })
+
+  describe('維持されるべき true（既存の正しい挙動を壊さない）', () => {
+    it('銀河数牌は同じ数字なら色自由（5索の銀河 と 5萬）', () => {
+      const [s5g, w5] = parseTiles('5sg5w')
+      expect(GALAXY_RULE.canBeSameTile(s5g, w5)).toBeTruthy()
+    })
+
+    it('銀河の風牌は同カテゴリの風牌と同一視できる（北の銀河 と 東）', () => {
+      const [ng] = parseTiles('ng')
+      const [w] = parseTiles('w') // w = 東(feng,1)
+      expect(GALAXY_RULE.canBeSameTile(ng, w)).toBeTruthy()
+    })
+
+    it('銀河の三元牌は同カテゴリの三元牌と同一視できる（發の銀河 と 白）', () => {
+      const [lg] = parseTiles('lg') // 發(sanyuan,2)
+      const [b] = parseTiles('b') // 白(sanyuan,1)
+      expect(GALAXY_RULE.canBeSameTile(lg, b)).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
## 概要
Issue #34 を修正します。銀河の字牌（風・三元）が、同じ内部 `number` を持つ数牌と同一視されてしまうバグ。

## 原因
`canBeSameTile`（`src/lib/mahjong/galaxy_rule.ts`）は片方が銀河牌のとき**非銀河側の色で switch** する。`feng`/`sanyuan` 枝は銀河側のカテゴリを対称に検査していたが、**`default`（数牌）枝だけ検査が抜けて** number 一致のみで `true` を返していた。風（東1南2西3北4）・三元（白1發2中3）は内部 number を持つため、`北g`(feng,4) と `4s`(siozi,4) 等が衝突。

## 修正
`default` 枝に「銀河側 `targetTile` も数牌（feng でも sanyuan でもない）であること」を AND する最小修正（src +11/-2）。

## テスト
`tests/unit/galaxy_rule/issue34_galaxy_honor_vs_number.spec.ts`（8件）。
- 直るべき `false`: `北g`vs`4s`、`西g`vs`3s/3w/3p`、`發(銀河)`vs`2*` 等
- 維持される `true`: `5sg`vs`5w`（数牌・色自由）、`北g`vs`東`（風同カテゴリ）、`發g`vs`白`（三元同カテゴリ）
- 期待値は `tile_map` の内部 number ＋ spec §1.3 由来。Red→Green 確認、全 **86 green**・回帰なし。

Closes #34
